### PR TITLE
Hookable Thread Abort (for RQL cleanup) + Per Endpoint Timeouts + Dynamic Timeouts

### DIFF
--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -151,7 +151,7 @@ module Rack
         end
 
         # NOTE: umbrellio-patch (START): an ability to set up custom hook for thread abort exception
-        ::Rack::Timeout.__custom_config[:on_thread_abort_hooks].each { |hook| hook.call(app_thread) }
+        ::Rack::Timeout.__custom_config[:on_thread_abort_hooks].each { |hook| hook.call(app_thread, @app, env) }
         # NOTE: umbrellio-patch (END): an ability to set up custom hook for thread abort exception
 
         app_thread.raise(RequestTimeoutException.new(env), message)

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -8,6 +8,16 @@ module Rack
   class Timeout
     include Rack::Timeout::MonotonicTime # gets us the #fsecs method
 
+    # NOTE: umbrellio-patch (START): an ability to set up custom hook for thread abort exception
+    @__custom_config = { on_thread_abort_hooks: Set.new }
+    class << self
+      attr_reader :__custom_config
+      def add_on_thread_abort_hook(&block)
+        __custom_config[:on_thread_abort_hooks] << block
+      end
+    end
+    # NOTE: umbrellio-patch (END): an ability to set up custom hook for thread abort exception
+
     module ExceptionWithEnv # shared by the following exceptions, allows them to receive the current env
       attr :env
       def initialize(env)
@@ -74,13 +84,6 @@ module Rack
       @service_past_wait = service_past_wait == "not_specified" ? ENV.fetch("RACK_TIMEOUT_SERVICE_PAST_WAIT", false).to_s != "false" : service_past_wait
 
       if @term_on_timeout && !::Process.respond_to?(:fork)
-        raise(NotImplementedError, <<-MSG)
-The platform running your application does not support forking (i.e. Windows, JVM, etc).
-
-To avoid this error, either specify RACK_TIMEOUT_TERM_ON_TIMEOUT=0 or
-leave it as default (which will have the same result).
-
-MSG
       end
       @app = app
     end
@@ -146,6 +149,10 @@ MSG
             message << ", #{Thread.main['RACK_TIMEOUT_COUNT']}/#{term_on_timeout} timeouts allowed before SIGTERM for process #{Process.pid}"
           end
         end
+
+        # NOTE: umbrellio-patch (START): an ability to set up custom hook for thread abort exception
+        ::Rack::Timeout.__custom_config[:on_thread_abort_hooks].each { |hook| hook.call(app_thread) }
+        # NOTE: umbrellio-patch (END): an ability to set up custom hook for thread abort exception
 
         app_thread.raise(RequestTimeoutException.new(env), message)
       end

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -154,7 +154,28 @@ MSG
         __req = ::Rack::Request.new(env)
 
         if ::Rack::Timeout.__custom_config[:dynamic_service_timeout]
-          ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(request: __req, env: env) || service_timeout
+          __dynamic_timeouter = ::Rack::Timeout.__custom_config[:dynamic_service_timeout]
+          __timeouter_signature = __dynamic_timeouter.parameters
+
+          case __timeouter_signature.size
+          when 2 # received request: and env: keyword attributes
+            # [[:keyreq, :request], [keyerq, :env]] or [[keyerq, :env], [:keyreq, :request]]
+            ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(request: __req, env: env) || service_timeout
+          when 1 # received request: or env: attribute
+            # [[:keyreq, :request]] or [[keyerq, :env]]
+            __required_attrbiute = timeouter_signature[0][1]
+
+            case __required_attrbiute
+            when :env
+              ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(env: env) || service_timeout
+            when :request
+              ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(request: __req) || service_timeout
+            end
+          when 0 # receive nothing
+            ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call || service_timeout
+          else
+            raise(ArgumentError, "Invalid timeouter signature. Should receive :request OR :env OR both of them OR nothing")
+          end
         else
           ::Rack::Timeout.__custom_config[:per_endpoint_service_timeout][__req.path] || service_timeout
         end

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -149,7 +149,7 @@ MSG
       # info.timeout = service_timeout # nice and simple, when service_past_wait is true, not so much otherwise:
       # NOTE: (umbrellio patch) end of OLD CODE
 
-      # NOTE: (umbrellio patch) custom per-endpoint timeouts (START of patch)
+      # NOTE: (umbrellio patch) custom timeouts (START of patch)
       final_service_timeout = begin
         req = ::Rack::Request.new(env)
 
@@ -162,7 +162,7 @@ MSG
 
       info.timeout = final_service_timeout
       info.timeout = seconds_service_left if !service_past_wait && seconds_service_left && seconds_service_left > 0 && seconds_service_left < final_service_timeout
-      # NOTE: (umbrellio patch) custom per-endpoint timeouts (END of patch)
+      # NOTE: (umbrellio patch) custom timeouts (END of patch)
 
       info.term    = term_on_timeout
       RT._set_state! env, :ready                            # we're good to go, but have done nothing yet

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -30,46 +30,12 @@ module Rack
         __custom_config[:per_endpoint_service_timeout][endpoint] = timeout
       end
 
-      # @param timeouter [Proc]
-      def dynamic_service_timeout=(timeouter)
-        unless timeouter.is_a?(::Proc)
+      def dynamic_service_timeout=(block)
+        unless block.is_a?(::Proc)
           raise(ArgumentError, "Dynamic timeout hook should be a type of proc/lambda")
         end
 
-        timeouter_signature = timeouter.parameters
-        is_valid_timeouter_signature =
-          case timeouter_signature.size
-          when 2 # proc interface => request: and env: keyword attributes
-            # [[:keyreq, :request], [keyerq, :env]] or [[keyerq, :env], [:keyreq, :request]]
-            f_attr = __timeouter_signature[0]
-            s_attr = __timeouter_signature[1]
-
-            if f_attr[0] == :keyreq && (f_attr[1] == :request || f_attr[1] == :env) &&
-               s_attr[0] == :keyreq && (s_attr[1] == :request || s_attr[1] == :env)
-              true
-            else
-              false
-            end
-          when 1 # proc interface => request: or env: attribute
-            # [[:keyreq, :request]] or [[keyerq, :env]]
-            f_attr = timeouter_signature[0]
-
-            if f_attr[0] == :keyreq && (f_attr[1] == :request || f_attr[1] == :env)
-              true
-            else
-              false
-            end
-          when 0
-            true
-          else
-            false
-          end
-
-        unless is_valid_timeouter_signature
-          raise(ArgumentError, "Invalid timeouter signature. Should receive :request OR :env OR both of them OR nothing")
-        end
-
-        __custom_config[:dynamic_service_timeout] = timeouter
+        __custom_config[:dynamic_service_timeout] = block
       end
     end
     # NOTE: umbrellio-patch (END)
@@ -190,28 +156,7 @@ MSG
         __req = ::Rack::Request.new(env)
 
         if ::Rack::Timeout.__custom_config[:dynamic_service_timeout]
-          __dynamic_timeouter = ::Rack::Timeout.__custom_config[:dynamic_service_timeout]
-          __timeouter_signature = __dynamic_timeouter.parameters
-
-          case __timeouter_signature.size
-          when 2 # proc interface => request: and env: keyword attributes
-            # [[:keyreq, :request], [keyerq, :env]] or [[keyerq, :env], [:keyreq, :request]]
-            ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(request: __req, env: env) || service_timeout
-          when 1 # proc interface => request: or env: attribute
-            # [[:keyreq, :request]] or [[keyerq, :env]]
-            __required_attrbiute = timeouter_signature[0][1]
-
-            case __required_attrbiute
-            when :env
-              ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(env: env) || service_timeout
-            when :request
-              ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(request: __req) || service_timeout
-            end
-          when 0 # proc interface => nothing
-            ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call || service_timeout
-          else
-            raise(ArgumentError, "Invalid timeouter signature. Should receive :request OR :env OR both of them OR nothing")
-          end
+          ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(__req, env) || service_timeout
         else
           ::Rack::Timeout.__custom_config[:per_endpoint_service_timeout][__req.path] || service_timeout
         end

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -150,7 +150,7 @@ MSG
       # NOTE: (umbrellio patch) end of OLD CODE
 
       # NOTE: (umbrellio patch) custom per-endpoint timeouts (START of patch)
-      endpoint_service_timeout = begin
+      final_service_timeout = begin
         req = ::Rack::Request.new(env)
 
         if ::Rack::Timeout.__custom_config[:dynamic_service_timeout]
@@ -160,8 +160,8 @@ MSG
         end
       end
 
-      info.timeout = endpoint_service_timeout
-      info.timeout = seconds_service_left if !service_past_wait && seconds_service_left && seconds_service_left > 0 && seconds_service_left < endpoint_service_timeout
+      info.timeout = final_service_timeout
+      info.timeout = seconds_service_left if !service_past_wait && seconds_service_left && seconds_service_left > 0 && seconds_service_left < final_service_timeout
       # NOTE: (umbrellio patch) custom per-endpoint timeouts (END of patch)
 
       info.term    = term_on_timeout

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -13,6 +13,7 @@ module Rack
     #   - an abiltiy to set up custom timeouts per endopoint
     @__custom_config = {
       on_thread_abort_hooks: Set.new,
+      dynamic_service_timeout: nil,
       per_endpoint_service_timeout: {}
     }
 
@@ -24,7 +25,15 @@ module Rack
       end
 
       def set_per_endpoint_service_timeout(endpoint, timeout)
-        __custom_config[endpoint] = timeout
+        __custom_config[:per_endpoint_service_timeout][endpoint] = timeout
+      end
+
+      def dynamic_service_timeout(block)
+        unless block.is_a?(::Proc)
+          raise(ArgumentError, "Dynamic timeout hook should be a type of proc/lambda")
+        end
+
+        __custom_config[:dynamic_service_timeout] = block
       end
     end
     # NOTE: umbrellio-patch (END)
@@ -142,8 +151,13 @@ MSG
 
       # NOTE: (umbrellio patch) custom per-endpoint timeouts (START of patch)
       endpoint_service_timeout = begin
-        current_path = ::Rack::Request.new(env).path
-        ::Rack::Timeout.__custom_config[:per_endpoint_timeout][current_path] || service_timeout
+        req = ::Rack::Request.new(env)
+
+        if ::Rack::Timeout.__custom_config[:dynamic_service_timeout]
+          ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(req) || service_timeout
+        else
+          ::Rack::Timeout.__custom_config[:per_endpoint_service_timeout][req.path] || service_timeout
+        end
       end
 
       info.timeout = endpoint_service_timeout

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -12,7 +12,7 @@ module Rack
     #   - an ability to set up custom hook for thread abort exception
     #   - an abiltiy to set up custom timeouts per endopoint
     @__custom_config = {
-      on_thread_abort_hooks: Set.new
+      on_thread_abort_hooks: Set.new,
       per_endpoint_service_timeout: {}
     }
 

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -8,15 +8,26 @@ module Rack
   class Timeout
     include Rack::Timeout::MonotonicTime # gets us the #fsecs method
 
-    # NOTE: umbrellio-patch (START): an ability to set up custom hook for thread abort exception
-    @__custom_config = { on_thread_abort_hooks: Set.new }
+    # NOTE: umbrellio-patch (START):
+    #   - an ability to set up custom hook for thread abort exception
+    #   - an abiltiy to set up custom timeouts per endopoint
+    @__custom_config = {
+      on_thread_abort_hooks: Set.new
+      per_endpoint_service_timeout: {}
+    }
+
     class << self
       attr_reader :__custom_config
+
       def add_on_thread_abort_hook(&block)
         __custom_config[:on_thread_abort_hooks] << block
       end
+
+      def set_per_endpoint_service_timeout(endpoint, timeout)
+        __custom_config[endpoint] = timeout
+      end
     end
-    # NOTE: umbrellio-patch (END): an ability to set up custom hook for thread abort exception
+    # NOTE: umbrellio-patch (END)
 
     module ExceptionWithEnv # shared by the following exceptions, allows them to receive the current env
       attr :env
@@ -119,8 +130,18 @@ module Rack
       return @app.call(env) unless service_timeout
 
       # compute actual timeout to be used for this request; if service_past_wait is true, this is just service_timeout. If false (the default), and wait time was determined, we'll use the shortest value between seconds_service_left and service_timeout. See comment above at service_past_wait for justification.
-      info.timeout = service_timeout # nice and simple, when service_past_wait is true, not so much otherwise:
-      info.timeout = seconds_service_left if !service_past_wait && seconds_service_left && seconds_service_left > 0 && seconds_service_left < service_timeout
+
+      # NOTE: (umbrellio patch) custom per-endpoint timeouts (OLD CODE)
+      # info.timeout = service_timeout # nice and simple, when service_past_wait is true, not so much otherwise:
+      # NOTE: (umbrellio patch) end of OLD CODE
+
+      endpoint_service_timeout = begin
+        current_path = Rack::Request.new(env).path
+        ::Rack::Timeout.__custom_config[:per_endpoint_timeout][current_path] || service_timeout
+      end
+
+      info.timeout = endpoint_service_timeout
+      info.timeout = seconds_service_left if !service_past_wait && seconds_service_left && seconds_service_left > 0 && seconds_service_left < endpoint_service_timeout
       info.term    = term_on_timeout
       RT._set_state! env, :ready                            # we're good to go, but have done nothing yet
 

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -95,6 +95,11 @@ module Rack
       @service_past_wait = service_past_wait == "not_specified" ? ENV.fetch("RACK_TIMEOUT_SERVICE_PAST_WAIT", false).to_s != "false" : service_past_wait
 
       if @term_on_timeout && !::Process.respond_to?(:fork)
+        raise(NotImplementedError, <<-MSG)
+The platform running your application does not support forking (i.e. Windows, JVM, etc).
+To avoid this error, either specify RACK_TIMEOUT_TERM_ON_TIMEOUT=0 or
+leave it as default (which will have the same result).
+MSG
       end
       @app = app
     end

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -141,7 +141,7 @@ MSG
       # NOTE: (umbrellio patch) end of OLD CODE
 
       endpoint_service_timeout = begin
-        current_path = Rack::Request.new(env).path
+        current_path = ::Rack::Request.new(env).path
         ::Rack::Timeout.__custom_config[:per_endpoint_timeout][current_path] || service_timeout
       end
 

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -154,7 +154,7 @@ MSG
         __req = ::Rack::Request.new(env)
 
         if ::Rack::Timeout.__custom_config[:dynamic_service_timeout]
-          ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(__req) || service_timeout
+          ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(request: __req, env: env) || service_timeout
         else
           ::Rack::Timeout.__custom_config[:per_endpoint_service_timeout][__req.path] || service_timeout
         end

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -151,12 +151,12 @@ MSG
 
       # NOTE: (umbrellio patch) custom timeouts (START of patch)
       final_service_timeout = begin
-        req = ::Rack::Request.new(env)
+        __req = ::Rack::Request.new(env)
 
         if ::Rack::Timeout.__custom_config[:dynamic_service_timeout]
-          ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(req) || service_timeout
+          ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(__req) || service_timeout
         else
-          ::Rack::Timeout.__custom_config[:per_endpoint_service_timeout][req.path] || service_timeout
+          ::Rack::Timeout.__custom_config[:per_endpoint_service_timeout][__req.path] || service_timeout
         end
       end
 

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -158,10 +158,10 @@ MSG
           __timeouter_signature = __dynamic_timeouter.parameters
 
           case __timeouter_signature.size
-          when 2 # received request: and env: keyword attributes
+          when 2 # proc interface => request: and env: keyword attributes
             # [[:keyreq, :request], [keyerq, :env]] or [[keyerq, :env], [:keyreq, :request]]
             ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(request: __req, env: env) || service_timeout
-          when 1 # received request: or env: attribute
+          when 1 # proc interface => request: or env: attribute
             # [[:keyreq, :request]] or [[keyerq, :env]]
             __required_attrbiute = timeouter_signature[0][1]
 
@@ -171,7 +171,7 @@ MSG
             when :request
               ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call(request: __req) || service_timeout
             end
-          when 0 # receive nothing
+          when 0 # proc interface => nothing
             ::Rack::Timeout.__custom_config[:dynamic_service_timeout].call || service_timeout
           else
             raise(ArgumentError, "Invalid timeouter signature. Should receive :request OR :env OR both of them OR nothing")

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -28,7 +28,7 @@ module Rack
         __custom_config[:per_endpoint_service_timeout][endpoint] = timeout
       end
 
-      def dynamic_service_timeout(block)
+      def dynamic_service_timeout=(block)
         unless block.is_a?(::Proc)
           raise(ArgumentError, "Dynamic timeout hook should be a type of proc/lambda")
         end

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -24,13 +24,49 @@ module Rack
         __custom_config[:on_thread_abort_hooks] << block
       end
 
+      # @param endpoint [String]
+      # @param timeout [Integer] in seconds
       def set_per_endpoint_service_timeout(endpoint, timeout)
         __custom_config[:per_endpoint_service_timeout][endpoint] = timeout
       end
 
-      def dynamic_service_timeout=(block)
+      # @param timeouter [Proc]
+      def dynamic_service_timeout=(timeouter)
         unless block.is_a?(::Proc)
           raise(ArgumentError, "Dynamic timeout hook should be a type of proc/lambda")
+        end
+
+        timeouter_signature = block.parameters
+        is_valid_timeouter_signature =
+          case timeouter_signature.size
+          when 2 # proc interface => request: and env: keyword attributes
+            # [[:keyreq, :request], [keyerq, :env]] or [[keyerq, :env], [:keyreq, :request]]
+            f_attr = __timeouter_signature[0]
+            s_attr = __timeouter_signature[1]
+
+            if f_attr[0] == :keyreq && (f_attr[1] == :request || f_attr[1] == :env) &&
+               s_attr[0] == :keyreq && (s_attr[1] == :request || s_attr[1] == :env)
+              true
+            else
+              false
+            end
+          when 1 # proc interface => request: or env: attribute
+            # [[:keyreq, :request]] or [[keyerq, :env]]
+            f_attr = timeouter_signature[0]
+
+            if f_attr[0] == :keyreq && (f_attr[1] == :request || f_attr[1] == :env)
+              true
+            else
+              false
+            end
+          when 0
+            true
+          else
+            false
+          end
+
+        unless is_valid_timeouter_signature
+          raise(ArgumentError, "Invalid timeouter signature. Should receive :request OR :env OR both of them OR nothing")
         end
 
         __custom_config[:dynamic_service_timeout] = block

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -32,11 +32,11 @@ module Rack
 
       # @param timeouter [Proc]
       def dynamic_service_timeout=(timeouter)
-        unless block.is_a?(::Proc)
+        unless timeouter.is_a?(::Proc)
           raise(ArgumentError, "Dynamic timeout hook should be a type of proc/lambda")
         end
 
-        timeouter_signature = block.parameters
+        timeouter_signature = timeouter.parameters
         is_valid_timeouter_signature =
           case timeouter_signature.size
           when 2 # proc interface => request: and env: keyword attributes
@@ -69,7 +69,7 @@ module Rack
           raise(ArgumentError, "Invalid timeouter signature. Should receive :request OR :env OR both of them OR nothing")
         end
 
-        __custom_config[:dynamic_service_timeout] = block
+        __custom_config[:dynamic_service_timeout] = timeouter
       end
     end
     # NOTE: umbrellio-patch (END)

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -140,6 +140,7 @@ MSG
       # info.timeout = service_timeout # nice and simple, when service_past_wait is true, not so much otherwise:
       # NOTE: (umbrellio patch) end of OLD CODE
 
+      # NOTE: (umbrellio patch) custom per-endpoint timeouts (START of patch)
       endpoint_service_timeout = begin
         current_path = ::Rack::Request.new(env).path
         ::Rack::Timeout.__custom_config[:per_endpoint_timeout][current_path] || service_timeout
@@ -147,6 +148,8 @@ MSG
 
       info.timeout = endpoint_service_timeout
       info.timeout = seconds_service_left if !service_past_wait && seconds_service_left && seconds_service_left > 0 && seconds_service_left < endpoint_service_timeout
+      # NOTE: (umbrellio patch) custom per-endpoint timeouts (END of patch)
+
       info.term    = term_on_timeout
       RT._set_state! env, :ready                            # we're good to go, but have done nothing yet
 


### PR DESCRIPTION
hookable thread abort:

```ruby
Rack::Timeout.add_on_thread_abort_hook  do |thread, app, env|
  # do something
end
```

per-endpoint timeouts:

```ruby
Rack::Timeout.set_per_endpoint_service_timeout("/some/endpoint", 30) # in seconds
```

dynamic timeouts:

```ruby
Rack::Timeout.dynamic_service_timeout = proc do |rack_request, rack_env|
   # rack_request is a Rack::Request
   # rack_env is a raw Rack's env variable from middleware stack

   # calculate Integer value (in seconds) or nil (treats as service_timeout)
end
```